### PR TITLE
Add the ability to suppress mdns service scans for some services

### DIFF
--- a/netdisco/discovery.py
+++ b/netdisco/discovery.py
@@ -45,7 +45,7 @@ class NetworkDiscovery:
         self.is_discovering = False
         self.discoverables = None
 
-    def scan(self, zeroconf_instance=None):
+    def scan(self, zeroconf_instance=None, suppress_mdns_types=None):
         """Start and tells scanners to scan."""
         self.is_discovering = True
 
@@ -53,6 +53,10 @@ class NetworkDiscovery:
 
         # Needs to be after MDNS init
         self._load_device_support()
+
+        if suppress_mdns_types:
+            for type_ in suppress_mdns_types:
+                self.mdns.unregister_type(type_)
 
         self.mdns.start()
 

--- a/netdisco/mdns.py
+++ b/netdisco/mdns.py
@@ -34,6 +34,15 @@ class MDNS:
         """Register a mDNS service."""
         self.services.append(service)
 
+    def unregister_type(self, type_):
+        """Unregister a mDNS type."""
+        removes = []
+        for service in self.services:
+            if service.typ == type_:
+                removes.append(service)
+        for service in removes:
+            self.services.remove(service)
+
     def start(self):
         """Start discovery."""
         try:


### PR DESCRIPTION
- When we are already running a ServiceBrowser for services that netdisco scans for
  we will already have all the answers we expect to get in the cache. By scanning
  for these services again, we generate additional network traffic. Since the
  known answer list was not shared between ServiceBrowsers in earlier versions
  of zeroconf, we will send an empty list which will cause every services we
  already have in the cache to be re-populated.